### PR TITLE
Update neewerlight_listener.cpp

### DIFF
--- a/components/neewerlight_ble/neewerlight_listener.cpp
+++ b/components/neewerlight_ble/neewerlight_listener.cpp
@@ -9,11 +9,10 @@ namespace neewerlight_ble {
 static const char *const TAG = "neewerlight_ble";
 
 bool NeewerLightListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
-  if (device.get_name() == "NEEWER-RGB660") {
+  if (device.get_name().find("NEEWER-") == 0) {
     ESP_LOGD(TAG, "Found Neewer Light %s (MAC: %s)", device.get_name().c_str(), device.address_str().c_str());
     return true;
   }
-
   return false;
 }
 


### PR DESCRIPTION
parse_device function that supports a wildcard name with anything starting with "NEEWER-":